### PR TITLE
Update rake dependency in gemspec due to vulnerability

### DIFF
--- a/jekyll-theme-hydejack.gemspec
+++ b/jekyll-theme-hydejack.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll-include-cache", "~> 0.2"
 
   spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.3.3"
 end


### PR DESCRIPTION
See CVE-2020-8130 for details.

## Remediation
Upgrade rake to version 12.3.3 or later. For example:

`spec.add_dependency "rake", ">= 12.3.3"`
or…
`spec.add_development_dependency "rake", ">= 12.3.3"`
Always verify the validity and compatibility of suggestions with your codebase.

## Details
```
CVE-2020-8130
moderate severity
Vulnerable versions: <= 12.3.2
Patched version: 12.3.3
There is an OS command injection vulnerability in Ruby Rake before 12.3.3 in Rake::FileList when supplying a filename that begins with the pipe character |.
```