### PR TITLE
Photo-gallery layout

### DIFF
--- a/_includes/styles/page-style.scss
+++ b/_includes/styles/page-style.scss
@@ -3,6 +3,8 @@
 
 html {
   --accent-color: {{ color }};
+  --accent-color-transparent:  #{transparentize({{ color }}, 0.5)};
+  --accent-color-transparent-darkened:  #{transparentize(darken({{ color }}, 30%), 0.2)};
   --accent-color-faded: #{fade-out({{ color }}, 0.5)};
   --accent-color-darkened: #{darken({{ color }}, 7.5%)};
   --theme-color: {{ theme_color }};

--- a/_includes/styles/style.scss
+++ b/_includes/styles/style.scss
@@ -83,6 +83,8 @@
   @import "hydejack/_katex.pre.scss";
   @import "hydejack/_footer.pre.scss";
 
+  @import "hydejack/_photo-feed.scss";
+
   {% unless site.hydejack.no_mark_external or site.no_mark_external %}
     @import "hydejack/_mark-external.pre.scss";
   {% endunless %}

--- a/_layouts/photo-feed.html
+++ b/_layouts/photo-feed.html
@@ -1,0 +1,68 @@
+---
+# Author: Gabriele Marini
+
+layout: base
+---
+
+
+<article class="page" role="article">
+  <header>
+    <h1 class="page-title">{{ page.title }}</h1>
+    {% include components/message.html text=page.description hide=page.hide_description %}
+  </header>
+  
+  {{ content }}
+
+  <div class="photo-feed">
+
+  {% assign photolist = site.data.photos %}
+  {% for photo in photolist.photos %}
+      {% if photo.file %}
+          {% if photo.highlight %}
+              <article class='photo-card' style="flex: 0 1 auto;">
+          {% else %}
+              <article class='photo-card'>
+          {% endif %}
+              <div class='photo-card-img img'>
+                  <img data-ignore src='{{ photolist.preview_folder }}{{ photo.file }}' loading='lazy'/>
+              </div>
+      {% else %}  
+          <article class='photo-card multiple multi-{{ photo.files.size }}'>
+              <div class='photo-card-img img'>
+              {% for file in photo.files %}
+                  <img data-ignore src='{{ photolist.preview_folder }}{{ file }}' loading='lazy'/>
+              {% endfor %}    
+              </div>
+      {% endif %}
+      <a href='{{ photo.url }}' class='no-hover no-print-link photo-card-caption'>
+          {% if photo.title.size > 0 %}
+              <div class='img-title'> <h3>{{ photo.title }}</h3></div>
+          {% endif %}
+          <div class='img-descr'> <p> {{ photo.caption }} </p> </div>
+      </a>     
+  {% if photo.location %}
+      <div class="location"> <span class="icon-location" style="font-size: 0.9rem;"> </span> {{ photo.location }}</div>
+  {% endif %}
+  </article>  
+  {% endfor %}    
+  </div>
+</article>
+
+  
+{% assign addons = page.addons | default:site.hydejack.post_addons %}
+{% unless addons %}{% assign addons = "about,newsletter,related,random" | split:"," %}{% endunless %}
+{% for addon in addons %}
+  {% case addon %}
+  {% when 'about' %}
+     {% include_cached components/about.html author=page.author %}
+  {% when 'newsletter' %}
+    {% include if-non-null try="pro/newsletter.html" %}
+  {% when 'related' %}
+    {% include if-non-null try="pro/related-posts.html" fallback="components/related-posts.html" %}
+  {% when 'random' %}
+    {% include if-non-null try="pro/random-posts.html" %}
+  {% when 'comments' %}
+    {% include body/comments.html %}
+  {% else %}
+  {% endcase %}
+{% endfor %}

--- a/_sass/hydejack/_photo-feed.scss
+++ b/_sass/hydejack/_photo-feed.scss
@@ -1,0 +1,238 @@
+
+  
+  .photo-feed {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-evenly;
+    align-items: center;
+    width: 100%;
+    height: auto;
+  }
+  
+  
+  .photo-feed .photo-card {
+    transition: all 250ms ease-out;
+    position: relative;
+    color: white !important;
+    overflow: hidden;
+    //box-shadow: #7d7d7d5c 2px 3px 5px 0;
+    margin-bottom: 1%;
+    flex: 0 1 47%;
+    -webkit-box-shadow: 0.125rem 0.125rem 1rem rgba(0, 0, 0, 0.2);
+    -moz-box-shadow: 0.125rem 0.125rem 1rem rgba(0, 0, 0, 0.2);
+    box-shadow: 0.125rem 0.125rem 1rem rgba(0, 0, 0, 0.2);
+  
+    img {
+      transition: all 250ms;
+      transform: scale(1.0);
+      filter: blur(0px);
+    }
+  
+    .photo-card-caption {
+      display: block;
+      background-color: var(--accent-color-transparent-darkened);
+      color: white !important;
+      position: absolute;
+      bottom: 0;
+      top: 0;
+      left: 0;
+      right: 0;
+      align-items: center;
+      justify-content: center;
+      align-content: center;
+      text-align: center;
+      width: 100%;
+      height: 100%;
+      vertical-align: middle;
+      line-height: 1;
+      padding: 10%;
+      transition: all 250ms;
+      transform: scale(1.1);
+      opacity: 0;
+  
+      .img-descr {
+        font-size: 100%;
+        line-height: 1.1;
+        text-align: center;
+  
+        p {
+          position: absolute;
+          top: 40%;
+          left: 0;
+          padding: 0 10%;
+        }
+      }
+  
+      .img-title {
+        font-size: 150%;
+        font-weight: bold;
+        margin-bottom: 5%;
+      }
+    }
+  
+    .location {
+      background-color: var(--gray-bg);
+      margin: 0;
+      padding: 1.5%;
+      color: grey;
+      margin: auto;
+      text-align: center;
+      font-weight: bold;
+      font-size: 0.9rem;
+      color: var(--body-color);
+    }
+  }
+  
+  .photo-feed .photo-card:hover,
+  .photo-feed .photo-card:active,
+  .photo-feed .photo-card:focus {
+    transition: all 250ms ease-out;
+    box-shadow: 0.125rem 0.375rem 1.15rem rgba(0, 0, 0, 0.25);
+    transform: translateY(-0.3rem);
+  
+    img {
+      transition: all 250ms ease-out;
+      transform: scale(1.05);
+      webkit-filter: blur(4px);
+      /* Chrome, Safari, Opera */
+      filter: blur(4px);
+    }
+  
+    .photo-card-caption {
+      transition: all 250ms ease-out;
+      transform: scale(1.0);
+      opacity: 1;
+    }
+  }
+  
+  
+  .photo-feed .photo-card.multiple {
+    flex: 0 1 99% !important;
+  }
+  .photo-feed .photo-card.multiple.multi-2 img {
+    width: 48%;
+  }
+  .photo-feed .photo-card.multiple.multi-3 img {
+    width: 32.5%;
+  }
+  .photo-feed .photo-card.multiple.multi-4 img {
+    width: 24%;
+  }
+  .photo-feed .photo-card.multiple.multi-5 img {
+    width: 19%;
+  }
+  
+  
+  //Content 64em
+  @media screen and (min-width: 64em) {
+    
+    .photo-feed .photo-card.multiple.multi-2 img {
+      width: 44.5%;
+    }
+    .photo-feed .photo-card.multiple.multi-3 img {
+      width: 33%;
+    }
+    .photo-feed .photo-card.multiple.multi-4 img {
+      width: 24.5%;
+    }
+    .photo-feed .photo-card.multiple.multi-5 img {
+      width: 19.5%;
+    }
+  }
+  
+  
+  @media screen and (max-width: 600px) {
+    .photo-feed .photo-card {
+      flex: 0 1 90%;
+    }
+  }
+  
+  /* ----------- Retina Screens ----------- */
+  @media screen and (min-device-width: 1200px) and (max-device-width: 1600px) and (-webkit-min-device-pixel-ratio: 2) and (min-resolution: 192dpi) {
+    .photo-feed .photo-card {
+      flex: 0 1 34%;
+    }
+  }
+  
+  @media (min-width: 2000px) {
+    .photo-feed {
+      -moz-column-count: 2;
+      -webkit-column-count: 2;
+      column-count: 2;
+    }
+  }
+  
+  @media (max-width: 2000px) {
+    .photo-feed {
+      -moz-column-count: 2;
+      -webkit-column-count: 2;
+      column-count: 2;
+    }
+  }
+  
+  @media (max-width: 1000px) {
+    .photo-feed {
+      -moz-column-count: 2;
+      -webkit-column-count: 2;
+      column-count: 2;
+    }
+  }
+  
+  @media (max-width: 800px) {
+    .photo-feed {
+      -moz-column-count: 1;
+      -webkit-column-count: 1;
+      column-count: 1;
+    }
+  }
+  
+  @media (max-width: 400px) {
+    .photo-feed {
+      -moz-column-count: 1;
+      -webkit-column-count: 1;
+      column-count: 1;
+    }
+  }
+  
+  
+  
+  //Content 64em
+  @media screen and (min-width: 64em) {
+    .content.layout-photo-feed {
+      padding-left: 1rem;
+      margin-left: 24rem;
+      margin-right: 3rem;
+      max-width: 60rem;
+    }
+  
+  }
+  //Content 88em
+  @media screen and (min-width: 88em) {
+    .content.layout-photo-feed {
+      margin-left: 25rem;
+      margin-right: 4rem;
+      max-width: 60rem;
+    }
+  }
+  
+  //Content 120em
+  @media screen and (min-width: 120em) {
+    .content.layout-photo-feed {
+      margin-left: 32rem;
+      max-width: 80rem;
+    }
+     
+    .photo-feed .photo-card {
+      flex: 0 1 32%;
+    }
+  }
+  
+  //Content 160em
+  @media screen and (min-width: 160em) {
+    .content.layout-photo-feed {
+      margin-left: 47rem;
+      max-width: 80rem;
+    }
+  }
+  
+  


### PR DESCRIPTION
Hey there,

I love your theme and I heavily customised it in my website. I thought the photo-gallery might actually be useful to other people who like me are hobbyist photographers.
You can see a demo of it on my website:  http://gabryxx7.com/photo/
Otherwise I tried it on the starter-kit and this is  a screenshot of what it looks like:

<img width="1906" alt="Capture" src="https://user-images.githubusercontent.com/6282055/89724855-86f7a380-da4b-11ea-9300-563e19d2dcfd.PNG">

The CSS is not **great** but I made sure it only applies to the .photo-feed page. which btw is also slightly wider than the usual page. I wanted to make a `page-full-width` layout but it did not feel right.

The pictures' metadata is loaded from the `photos.yml` file in `_data` folder, the one of the starter kit looks something like this:
```yaml
preview_folder: /assets/img/blog/
full_folder: /assets/img/blog/
photos:
  - file: caleb-george.jpg
    title: 
    caption: |
      This is a test caption! Oh look, some `code`
    date: 2020-06-28T13:19:48+00:00
    location: This website
    url: http://www.gabryxx7.com
  - file: steve-harvey.jpg
    title: 
    caption: |
      This is a test caption! Oh look, some `code`
    date: 2020-06-28T12:14:27+00:00
    url: http://www.gabryxx7.com
  - file: hydejack-9.jpg
    title: 
    caption: |
      Some more testing
    date: 2020-06-12T22:27:33+00:00
    url: http://www.gabryxx7.com
    location: This website
    highlight: true
  - files: 
    - wade-lambert.jpg
    - cover-page.jpg
    - grid.jpg
    title: 
    caption: |
      This three (or more) photos will me grouped together and showed in a single row. Good for panorama split pics.
    date: 2020-06-08T12:29:12+00:00
    url: http://www.gabryxx7.com
```

While the files themselves can be loaded from anywhere, of course it's best to keep them in the `assets` folder. I Automatically generated this list from an export of my instagram data.

While the new page `photos.md` it's very simple:
```markdown
---
layout: photo-feed
title: Photos
addons: [comments, about]
---
```

Not sure I followed the right process as I have never worked with `ruby`. I just cloned your repo into a folder `#jekyll-theme-hydejack` and redirected the `gem` to the local folder I then just run `bundle install` and `npm install webpack --save-dev` to generated the files. Finally `jekyll serve` on the website and it seemed fine to me.
