### PR TITLE
Fix disqus embed.js link

### DIFF
--- a/_includes/my-comments.html
+++ b/_includes/my-comments.html
@@ -17,7 +17,7 @@
         this.page.url = w.location.href;
         this.page.title = d.title;
       };
-      w.loadJSDeferred(d.getElementById("_hrefDisqus").href + '/embed.js');
+      w.loadJSDeferred(d.getElementById("_hrefDisqus").href + 'embed.js');
     }
   }
 }(window, document);</script>


### PR DESCRIPTION
`d.getElementById("_hrefDisqus").href` generates link ends with `/` thus (in my blog for example)

original code will load [default embed.js](https://a.disquscdn.com/embed.js) since it cannot find `https://lazyrengithub.disqus.com//embed.js`

by simply removing `/` fix this issue by loading right url(`https://lazyrengithub.disqus.com/embed.js`).