### PR TITLE
Don't use include_cache on head/links.html

### DIFF
--- a/_includes/head/index.html
+++ b/_includes/head/index.html
@@ -5,7 +5,7 @@
 {% include        head/meta.html %}
 {% include_cached head/meta-static.html %}
 
-{% include_cached head/links.html lang=page.lang %}
+{% include        head/links.html lang=page.lang %}
 {% include_cached head/links-static.html %}
 
 {% include_cached head/scripts.html %}


### PR DESCRIPTION
This resolves an issue where the base index page would include the wrong URL for a would-be self-referencing hreflang link.

For example, today https://hydejack.com has a would-be self link as follows:
```html
<link rel="alternate" href="https://hydejack.com/blog/hyde/2012-02-06-whats-jekyll/" hreflang="en">
```

After changing to `include` from `include_cache`, it would be correct:
```html
<link rel="alternate" href="https://hydejack.com/" hreflang="en">
```
