### PR TITLE
Fix separator for pages under multiple categories

### DIFF
--- a/_includes/components/post.html
+++ b/_includes/components/post.html
@@ -22,10 +22,10 @@
         {%- endunless -%}
         {{ ' ' }}
         {%- assign category_start     = site.data.strings.category_start     | default:"in " -%}
-        {%- assign tag_start          = site.data.strings.tag_start          | default:"on " -%}
+        {%- assign category_separator = site.data.strings.category_separator | default:" / " -%}
         {%- include components/tag-list.html tags=post.categories meta=site.featured_categories start_with=category_start separator=category_separator -%}
         {{ ' ' }}
-        {%- assign category_separator = site.data.strings.category_separator | default:" / " -%}
+        {%- assign tag_start          = site.data.strings.tag_start          | default:"on " -%}
         {%- assign tag_separator      = site.data.strings.tag_separator      | default:", "  -%}
         {%- include components/tag-list.html tags=post.tags meta=site.featured_tags start_with=tag_start separator=tag_separator -%}
       {% endcapture %}


### PR DESCRIPTION
The variable `category_separator` was initialized after including `components/tag-list.html` for categories, so it wasn't available when needed. This resulted in category names just being slammed together rather than separated appropriately.

This commit fixes that.