### PR TITLE
add `rel="me"` to social links

### DIFF
--- a/_includes/components/social-list-item.html
+++ b/_includes/components/social-list-item.html
@@ -32,7 +32,7 @@
   {% endif %}
 
   <li>
-    <a href="{{ url }}" title="{{ name }}" class="no-mark-external">
+    <a href="{{ url }}" rel="me" title="{{ name }}" class="no-mark-external">
       <span class="{{ icon }}"></span>
       <span class="sr-only">{{ name }}</span>
     </a>


### PR DESCRIPTION
advantage: Mastodon looks for profile links with rel=me attribute for link verification