### PR TITLE
add discord links for sidebar

### DIFF
--- a/_includes/components/social-list-item.html
+++ b/_includes/components/social-list-item.html
@@ -22,6 +22,10 @@
       {% assign name = "GitHub" %}
       {% assign icon = "icon-github" %}
       {% assign prep = "https://github.com/" %}
+    {% elsif platform == "discord" %}
+      {% assign name = "Discord" %}
+      {% assign icon = "icon-bubble" %}
+      {% assign prep = "https://discord.gg/" %}
     {% endif %}
   {% endunless %}
 

--- a/_includes/components/social.html
+++ b/_includes/components/social.html
@@ -15,6 +15,11 @@
       {% include components/social-list-item.html platform="github" username=github_username %}
     {% endif %}
 
+    {% assign discord_server = author.discord.server | default: author.discord | default:site.discord.server | default:site.discord | default:site.discord_server %}
+    {% if discord_server %}
+      {% include components/social-list-item.html platform="discord" username=discord_server %}
+    {% endif %}
+
     {% assign email = author.email | default: site.email %}
     {% if email %}
       {% include components/social-list-item.html platform="email" username=email %}


### PR DESCRIPTION
I thought this would be a helpful addition.  If there's anything you'd like added to the docs, etc, please let me know.

I didn't see a Discord icon in the basic set, so I chose `bubbles`

<img width="198" alt="image" src="https://github.com/hydecorp/hydejack/assets/87758/51fd642d-c88a-4f6c-aec7-4f5b5e1b7833">
